### PR TITLE
Add Consents and ContextInfo objects

### DIFF
--- a/contacthub/models/customer.py
+++ b/contacthub/models/customer.py
@@ -33,6 +33,7 @@ class Customer(with_metaclass(EntityMeta, object)):
                     'contacts': {}
                     },
             'extended': {},
+            'consents': {},
             'tags': {
                     'manual': [],
                     'auto': []
@@ -51,6 +52,9 @@ class Customer(with_metaclass(EntityMeta, object)):
 
             if 'extended' not in attributes or attributes['extended'] is None:
                 attributes['extended'] = {}
+
+            if 'consents' not in attributes or attributes['consents'] is None:
+                attributes['consents'] = {}
 
             if 'tags' not in attributes or attributes['tags'] is None:
                 attributes['tags'] = {'auto': [], 'manual': []}

--- a/doc/source/customer_operation.rst
+++ b/doc/source/customer_operation.rst
@@ -19,18 +19,17 @@ method takes as parameter a dictionary containing the structure of your new cust
 object::
 
     customer_structure = {
-                            'externalId': '01',
-                            'extra': 'extra',
-                            'base':
-                                    {
-                                    'timezone': 'Europe/Rome',
-                                    'firstName': 'Bruce',
-                                    'lastName': 'Wayne',
-                                    'contacts': {
-                                                'email': 'email@email.com'
-                                                }
-                                    }
-                            }
+                         'externalId': '01',
+                         'extra': 'extra',
+                         'base': {
+                                 'timezone': 'Europe/Rome',
+                                 'firstName': 'Bruce',
+                                 'lastName': 'Wayne',
+                                 'contacts': {
+                                             'email': 'email@email.com'
+                                             }
+                                 }
+                          }
 
     my_customer = node.add_customer(**customer_structure)
 
@@ -45,6 +44,13 @@ and converting it to a dictionary::
     post_customer.base.contacts.email = 'email@example.com'
     post_customer.extra = 'extra'
     post_customer.extended.my_string = 'my new extended property string'
+    post_customer.consents = {
+        'marketing': {
+            'automatic': {
+                'email': {'status': True, 'limitation': False, 'objection': False}
+            }
+        }
+    }}
 
     new_customer = node.add_customer(**post_customer.to_dict())
 

--- a/doc/source/customer_operation.rst
+++ b/doc/source/customer_operation.rst
@@ -55,6 +55,7 @@ When you declare a new `Customer`, by default its internal structure start with 
             'contacts': {}
             },
     'extended': {},
+    'consents': {},
     'tags': {
             'manual':[],
             'auto':[]

--- a/doc/source/customer_operation.rst
+++ b/doc/source/customer_operation.rst
@@ -50,7 +50,7 @@ and converting it to a dictionary::
                 'email': {'status': True, 'limitation': False, 'objection': False}
             }
         }
-    }}
+    }
 
     new_customer = node.add_customer(**post_customer.to_dict())
 

--- a/doc/source/event_operations.rst
+++ b/doc/source/event_operations.rst
@@ -46,14 +46,30 @@ Events are also associated to a context of use. The available contexts for an ev
 
 When you create an `Event`, the attributes `type`, `context` and `properties` are required.
 
+For each type of `context`, you can also provide some additional properties in
+the optional `contextInfo` object. The schema for this object varies depending
+on the specified `context`. All the schemas can be found at `this link
+<http://developer.contactlab.com/documentation/contacthub/schemas/index />`_.
+
 Add a new event
 ---------------
 To create a new event, you have to define its schema (according to the specified type) in `Event` class constructor::
 
-    event = Event(node=node, customerId=my_customer.id, type=Event.TYPES.SERVICE_SUBSCRIBED, context=Event.CONTEXTS.WEB,
-                  properties=Properties(
-                  subscriberId='s_id', serviceId='service_id', serviceName='serviceName', startDate=datetime.now(),
-                  extraProperties=Properties(extra='extra')))
+    event = Event(
+        node=node,
+        customerId=my_customer.id,
+        type=Event.TYPES.SERVICE_SUBSCRIBED,
+        context=Event.CONTEXTS.WEB,
+        contextInfo=Properties(
+            client=Properties(
+                ip="127.0.0.1"
+            )
+        )
+        properties=Properties(
+            subscriberId='s_id', serviceId='service_id', serviceName='serviceName', startDate=datetime.now(),
+            extraProperties=Properties(extra='extra')
+        )
+    )
 
 **The attribute `customerId` is required for specifying the customer who will be associated with the event.**
 

--- a/doc/source/event_operations.rst
+++ b/doc/source/event_operations.rst
@@ -64,7 +64,7 @@ To create a new event, you have to define its schema (according to the specified
             client=Properties(
                 ip="127.0.0.1"
             )
-        )
+        ),
         properties=Properties(
             subscriberId='s_id', serviceId='service_id', serviceName='serviceName', startDate=datetime.now(),
             extraProperties=Properties(extra='extra')
@@ -118,7 +118,7 @@ ExternalId
 
 In the same way of the Session ID, you can add a new event specifying the external ID of a customer::
 
-    from contacthub.model import Event
+    from contacthub.models import Event
 
     event = Event(node=node, bringBackProperties=Properties(type='externalId', value='e_id'),
     type=Event.TYPES.SERVICE_SUBSCRIBED, context=Event.CONTEXTS.WEB,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(description='This is the official Python SDK for Contacthub REST API. This
                   'on Contacthub, making the authentication immediate and simplifying read/write operations.',
       author='Contactlab',
       url='https://github.com/contactlab/contacthub-sdk-python',
-      version='0.2',
+      version='0.3',
       classifiers=['Intended Audience :: Developers',
                    'Programming Language :: Python',
                    'Programming Language :: Python :: 2.6',

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -310,7 +310,10 @@ class TestCustomer(unittest.TestCase):
     @mock.patch('contacthub._api_manager._api_customer._CustomerAPIManager.post')
     def test_post_customer_creation_first_method(self, mock_post):
         expected_body = {'base': {'contacts': {'email': 'email@email.email'}}, 'extra': 'extra',
-                         'extended': {'prova': 'prova'}, 'tags': {'auto': ['auto'], 'manual': ['manual']}}
+                         'extended': {'prova': 'prova'}, 'tags': {'auto': ['auto'], 'manual': ['manual']},
+                         'consents': {'marketing': {'automatic': {'email':
+                             {'status': True, 'limitation': False, 'objection': False}}}
+                             }}
         mock_post.return_value = json.loads(FakeHTTPResponse(resp_path='tests/util/fake_post_response').text)
         c = Customer(node=self.node,
                      base=Properties(
@@ -322,6 +325,7 @@ class TestCustomer(unittest.TestCase):
         c.extended.prova = 'prova'
         c.tags.auto = ['auto']
         c.tags.manual = ['manual']
+        c.consents = {'marketing': {'automatic': {'email': {'status': True, 'limitation': False, 'objection': False}}}}
 
         c.post()
         mock_post.assert_called_with(body=expected_body, force_update=False)
@@ -343,7 +347,7 @@ class TestCustomer(unittest.TestCase):
     @mock.patch('contacthub._api_manager._api_customer._CustomerAPIManager.post')
     def test_post_customer_creation_second_method(self, mock_post):
         expected_body = {'base': {'contacts': {'email': 'email@email.email'}}, 'extra': 'extra', 'extended': {},
-                         'tags': {'auto': [], 'manual': []}}
+                         'tags': {'auto': [], 'manual': []}, 'consents': {}}
         mock_post.return_value = json.loads(FakeHTTPResponse(resp_path='tests/util/fake_post_response').text)
         c = Customer(node=self.node, base=Properties())
         c.base.contacts = {'email': 'email@email.email'}
@@ -535,5 +539,5 @@ class TestCustomer(unittest.TestCase):
         c.base.timezone = None
         c.put()
         params_expected= {'id':'01', 'base': {'contacts': {}, 'timezone':'Europe/Rome'}, 'extended': {},
-                          'tags':{'manual':[], 'auto':[]}}
+                           'tags':{'manual':[], 'auto':[]}, 'consents':{}}
         mock_put.assert_called_with(self.base_url_customer + '/01', headers=self.headers_expected, json=params_expected)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -116,7 +116,7 @@ class TestNode(TestSuite):
         c = Customer(node=self.node, base=Properties(contacts=Properties(email='email')))
         self.node.add_customer(**c.to_dict())
         body = {'nodeId': self.node.node_id, 'base': {'contacts': {'email': 'email'}}, 'extended': {},
-                'tags': {'auto': [], 'manual': []}}
+                'tags': {'auto': [], 'manual': []}, 'consents':{}}
         mock_get.assert_called_with(self.base_url, headers=self.headers_expected, json=body)
 
     @mock.patch('requests.post', return_value=FakeHTTPResponse())
@@ -125,7 +125,7 @@ class TestNode(TestSuite):
         c.extended.prova = 'prova'
         self.node.add_customer(**c.to_dict())
         body = {'nodeId': self.node.node_id, 'base': {'contacts': {'email': 'email'}}, 'extended': {'prova': 'prova'},
-                'tags': {'auto': [], 'manual': []}}
+                'tags': {'auto': [], 'manual': []}, 'consents':{}}
         mock_get.assert_called_with(self.base_url, headers=self.headers_expected, json=body)
 
     @mock.patch('requests.post', return_value=FakeHTTPResponse())
@@ -136,7 +136,7 @@ class TestNode(TestSuite):
         c.tags.manual = ['manual']
         self.node.add_customer(**c.to_dict())
         body = {'nodeId': self.node.node_id, 'base': {'contacts': {'email': 'email'}}, 'extended': {'prova': 'prova'},
-                'tags': {'auto': ['auto'], 'manual': ['manual']}}
+                'tags': {'auto': ['auto'], 'manual': ['manual']}, 'consents':{}}
         mock_get.assert_called_with(self.base_url, headers=self.headers_expected, json=body)
 
     @mock.patch('requests.patch', return_value=FakeHTTPResponse())
@@ -153,7 +153,7 @@ class TestNode(TestSuite):
         c.base.contacts.email = 'email1234'
         self.node.update_customer(full_update=True, **c.to_dict())
         body = {'id': '01', 'base': {'contacts': {'email': 'email1234', 'fax': 'fax'}}, 'extended': {},
-                'tags': {'auto': [], 'manual': []}}
+                'tags': {'auto': [], 'manual': []}, 'consents':{}}
         mock_get.assert_called_with(self.base_url + '/01', headers=self.headers_expected, json=body)
 
     @mock.patch('requests.post',


### PR DESCRIPTION
## Test Plan

Using the Python REPL, I successfully

* created an event with `contextInfo`, using the example added to the docs:

```python
event = Event(
    node=node,
    customerId=my_customer.id,
    type=Event.TYPES.SERVICE_SUBSCRIBED,
    context=Event.CONTEXTS.WEB,
    contextInfo=Properties(
        client=Properties(
            ip="127.0.0.1"
        )
    )
    properties=Properties(
        subscriberId='s_id', serviceId='service_id', serviceName='serviceName', startDate=datetime.now(),
        extraProperties=Properties(extra='extra')
    )
)
```

* updated a customer adding a `consents` object, using the example that was added to the docs:

```python
post_customer.consents = {
    'marketing': {
        'automatic': {
            'email': {'status': True, 'limitation': False, 'objection': False}
        }
    }
}
```

* verified that both `consents` and `contextInfo` appear correctly in the Hub web interface.